### PR TITLE
Drop support for Python 2.5 for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.5"
   - "2.6"
   - "2.7"
   - "3.2"


### PR DESCRIPTION
Fixes issue #21. Travis CI has dropped support for Python 2.5, thus we should remove it from our Travis config.
