### PR TITLE
Fix software name in license text

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -2,7 +2,7 @@ This Python module is licensed under a `CC0
 license <http://creativecommons.org/publicdomain/zero/1.0/>`__.
 
 To the extent possible under law, Eduard Bopp has waived all copyright
-and related or neighboring rights to event. This work is published from:
+and related or neighboring rights to obsub. This work is published from:
 Germany.
 
 Full license text


### PR DESCRIPTION
This error managed to sneak in when the module was renamed. I assume, it is sufficient to change it now and not fix the entire history, is it not?
