### PR TITLE
Add pypip.in badges for current version, license and downloads on pypi

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 obsub
 =====
 
+|Build Status| |Version| |Downloads| |License|
+
 Small python module that implements the observer pattern via a
 decorator.
 
@@ -96,5 +98,14 @@ Credits
 Thanks to Jason Orendorff on for the idea on stackoverflow. I also want
 to thank @coldfix and @Moredread for contributions and feedback.
 
+.. |Downloads| image:: https://pypip.in/d/obsub/badge.png
+   :target: https://pypi.python.org/pypi/obsub/
+   :alt: Downloads
+.. |Version| image:: https://pypip.in/v/obsub/badge.png
+   :target: https://pypi.python.org/pypi/obsub/
+   :alt: Latest Version
+.. |License| image:: https://pypip.in/license/obsub/badge.png
+   :target: https://pypi.python.org/pypi/obsub/
+   :alt: License
 .. |Build Status| image:: https://api.travis-ci.org/aepsil0n/obsub.png?branch=master
    :target: https://travis-ci.org/aepsil0n/obsub


### PR DESCRIPTION
pypip.in provides badges for different metrics pulled from pypi, e.g. version,
license, recent downloads, if the project provides eggs or wheels, etc. Those are
used in the README, to provide useful informations to a visitor of the projects
github page.

The build status badge from Travis is also added to the top of the README, so it
is better visible on the github page.

Other badges should also be added at the top for visibility.
