### PR TITLE
Test removal of event handlers

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -62,6 +62,7 @@ class TestCore(unittest.TestCase):
         src = self.cls()
         obs = self.observer(src)
         src.emit -= obs
+        src.emit("something", "arbitrary")
         self.check_stack([])
 
     def test_multiple_handlers(self):


### PR DESCRIPTION
This test was missing as seen in the coverage report. Fixes issue #31.
