### PR TITLE
Provide contact email address in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,7 @@ send an email one of us:
 
 - `Eduard Bopp <eduard.bopp@aepsil0n.de>`__
 - `André-Patrick Bubel <code@andre-bubel.de>`__
+- `Thomas Gläßle <t_glaessle@gmx.de>`__
 
 Feel free to contribute patches as pull requests as you see fit. Try to be
 consistent with PEP 8 guidelines as far as possible and test everything.


### PR DESCRIPTION
Due to issue #21, I wanted to provide this at least as an option. This "infrastructure" is maybe a bit lighter than a mailing list. Ideally I would like to add others that have contributed significant code to this module (@coldfix and @Moredread obviously) as well but this is not necessary.

Edit: To clarify let me state it as an explicit question: does anybody else want to be added?
