### PR TITLE
Bump version to 0.2

### DIFF
--- a/obsub.py
+++ b/obsub.py
@@ -25,6 +25,7 @@ except ImportError: # pragma: no cover
         return None
 
 __all__ = ['event']
+__version__ = '0.2'
 
 
 class event(object):
@@ -219,4 +220,3 @@ class boundevent(object):
         for f in self.__event_handlers[:]:
             f(self.instance, *args, **kwargs)
         return result
-

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ f.close()
 
 setup(
     name='obsub',
-    version='0.1.1',
+    version='0.2',
     description='Implementation of the observer pattern via a decorator',
     long_description=long_description,
     author='Eduard Bopp',


### PR DESCRIPTION
This bumps the version and also begins to follow the de-facto convention of having a `__version__` attribute at the top level of a module/package.

Should be merged after everything else relevant to 0.2
