### PR TITLE
Added EventMetaclass

### DIFF
--- a/obsub.py
+++ b/obsub.py
@@ -234,15 +234,15 @@ class EventMetaclass(type):
     options
     
     1. Add the @event decorator in Foo. This is a bad option because it
-       requires us to modify someone elses class. This may not be possible or
+       requires us to modify someone else's class. This may not be possible or
        permissible.
     
-    2. Subclass Foo and re-implement .bar with the @event decorator. This
+    2. Subclass Foo and reimplement .bar with the @event decorator. This
        is a reasonable option but could get annoying if we have to
        re-implement a lot of methods.
     
     The other option is to use this metaclass to add the @event decorator for
-    us. The metclass intercepts the definition of methods when our class is
+    us. The metaclass intercepts the definition of methods when our class is
     being constructed and adds the @event decorator to the ones we specify in
     a class level attribute _event_methods, which is a list of method names to
     which we want the @event decorator applied.
@@ -280,9 +280,7 @@ class EventMetaclass(type):
             for m in d['_event_methods']:
                 d[m] = event(find_method(m))
         except KeyError:
-            msg = "Use of EventMetaclass requires a class level variable"
-            msg += " '_event_methods' which is a list of names of methods"
-            msg += " to be decorated by @event"
+            msg = "class level attribute _event_methods not found"
             raise RuntimeError(msg)
         return type(name, bases, d)
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9,6 +9,7 @@ import unittest
 import weakref, gc
 
 # tested module
+import obsub
 from obsub import event
 
 
@@ -18,6 +19,16 @@ class NewStyle(object):
     @event
     def emit(self, first, second):
         self.count += 1
+
+class NewStyleNoDecorator(object):
+    def __init__(self):
+        self.count = 0
+    def emit(self, first, second):
+        self.count += 1
+
+class NewStyleWithMeta(NewStyleNoDecorator):
+    __metaclass__ = obsub.EventMetaclass
+    _event_methods = ['emit']
 
 class OldStyle:
     def __init__(self):
@@ -127,6 +138,9 @@ class TestCore(unittest.TestCase):
         self.call_stack[0] = None
         gc.collect()
         assert wr() is None
+
+class TestCoreMeta(TestCore):
+    cls = NewStyleWithMeta
 
 # ERRORS:
 class TestCoreOldStyle(TestCore):


### PR DESCRIPTION
Suppose you have a class Foo which has a method .bar to which you'd like to apply the @event decorator, but that class is defined externally to your project. You're stuck subclassing Foo and re-implementing .bar with manual addition of the @event decorator. That's ok for some cases, but it's kind of ugly and can be really tedious.

In this submission I introduce a metaclass so that the @event decorator can be applied to specified methods _at class construction time_. A full explanation with a working example are given in the docstring of obsub.EventMetaclass, but here's the basic idea

```
class Foo(object):
    def bar(self, arg):
        print("bar called with argument %s"%(arg,))


class MySubclass(Foo):
    __metaclass__ = obsub.EventMetaclass
    _event_methods = ['bar']


def callback(obj, arg):
    print("callback fired with argument %s"%(arg,))

f = MySubclass()
f.bar += callback
f.bar('baz')
> bar called with argument baz
> callback fired with argument baz
```
